### PR TITLE
Remove obsolete ~buffer_size from Lwt_io.open_connection call.

### DIFF
--- a/src/smtp_lwt.ml
+++ b/src/smtp_lwt.ml
@@ -11,7 +11,7 @@ module IO = struct
   let open_connection ~host ~service =
     Lwt_unix.getaddrinfo host service [] >>= function
     | [] -> fail (Failure ("IP resolution failed for " ^ host))
-    | h::t -> Lwt_io.open_connection ~buffer_size:4096 h.Lwt_unix.ai_addr
+    | h::t -> Lwt_io.open_connection h.Lwt_unix.ai_addr
 
   let shutdown_connection = Lwt_io.close
 


### PR DESCRIPTION
The library does not compile in the 4.02.3 opam switch (at least), since `Lwt_io.open_connection` no longer accepts `~buffer_size`.  I suggest removing it, since it's the default anyway [[1](https://github.com/ocsigen/lwt/blob/master/src/unix/lwt_io.ml#L41)].
